### PR TITLE
BW-1177 Add Swagger path, update link

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Developing BatchAnalysis 
+# Developing BatchAnalysis
 
 TODO: Complete me! Should be of similar quality to the ECM documentation.
 
@@ -34,9 +34,9 @@ that seems "off" is probably a result of that. Feel free to submit a PR to fix t
 ### Database Configuration
 The Batch Analysis service relies on a Postgresql database server. There are two options for running the Postgres server:
 
-- Manual setup:  
+- Manual setup:
   Setup Postgres using whatever method you like.
-- Convenient app setup:  
+- Convenient app setup:
   Install [the convenient app](https://postgresapp.com/), and create a database called `bio.terra.batchanalysis`.
 
 #### Initialize your database:
@@ -49,7 +49,7 @@ psql -h 127.0.0.1 -U postgres -f ./common/postgres-init.sql
 
 ### Running Tests
 
-Unit tests will run on build.  Integration tests can be run by following the instructions in the [integration README](/integration/README.md). 
+Unit tests will run on build.  Integration tests can be run by following the instructions in the [integration README](/integration/README.md).
 
 ### Running The Service Locally
 
@@ -60,11 +60,11 @@ cd service
 ../gradlew bootRun
 ```
 
-Then navigate to the Swagger: `http://localhost:8080/`
+Then navigate to the Swagger: `http://localhost:8080/swagger-ui.html`
 
 ### IntelliJ Setup
 
-1. Open the repo normally (File > New > Project From Existing Sources). Select the folder, and then select Gradle as the external model. 
+1. Open the repo normally (File > New > Project From Existing Sources). Select the folder, and then select Gradle as the external model.
 2. In project structure (the folder icon with a little tetromino over it in the upper
    right corner), make sure the project SDK is set to Java 17. If not, IntelliJ should
    detect it on your system in the dropdown, otherwise click "Add JDK..." and navigate to
@@ -77,8 +77,8 @@ Then navigate to the Swagger: `http://localhost:8080/`
 ## Tips
 - Check out [gdub](https://github.com/gdubw/gdub), it'll save you typing `./gradlew` over
   and over, and also takes care of knowing when you're not in the root directory so you
-  don't have to figure out the appropriate number of `../`s. 
+  don't have to figure out the appropriate number of `../`s.
 - In IntelliJ, instead of running the local server with `bootRun`, use the `TerraBatchAnalysisApplication` Spring
   Boot configuration that IntelliJ auto-generates. To edit it, click on it (in the upper
-  right of the window), and click `Edit Configurations`. 
-    - For readable logs, put `human-readable-logging` in the `Active Profiles` field. 
+  right of the window), and click `Edit Configurations`.
+    - For readable logs, put `human-readable-logging` in the `Active Profiles` field.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,7 +75,7 @@ Then navigate to the Swagger: `http://localhost:8080/swagger-ui.html`
 4. See some optional tips below in the ["Tips"](#tips) section.
 
 ## Tips
-- Check out [gdub](https://github.com/gdubw/gdub), it'll save you typing `./gradlew` over
+- Check out [gng](https://github.com/gdubw/gng), it'll save you typing `./gradlew` over
   and over, and also takes care of knowing when you're not in the root directory so you
   don't have to figure out the appropriate number of `../`s.
 - In IntelliJ, instead of running the local server with `bootRun`, use the `TerraBatchAnalysisApplication` Spring


### PR DESCRIPTION
There is no redirect yet and hitting the bare path shows an error.

Apologies for the trailing whitespace spam. IntelliJ absolutely insists on doing it, even when I disable in Preferences > Editor > General > On Save