### PR TITLE
BW-1250 Basic status check against Cromwell URL

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
@@ -1,0 +1,6 @@
+package bio.terra.cbas.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "workflow-engines.cromwell")
+public record CromwellServerConfiguration(String baseUri, String healthUri) {}

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -4,11 +4,12 @@ import bio.terra.cbas.api.PublicApi;
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.model.SystemStatus;
 import bio.terra.cbas.model.SystemStatusSystems;
+import java.net.URL;
+import java.net.URLConnection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.client.RestTemplate;
 
 @Controller
 public class PublicApiController implements PublicApi {
@@ -23,11 +24,15 @@ public class PublicApiController implements PublicApi {
   @Override
   public ResponseEntity<SystemStatus> getStatus() {
 
-    RestTemplate restTemplate = new RestTemplate();
     String result;
-    Boolean isOk;
+    boolean isOk;
     try {
-      result = restTemplate.getForObject(this.cromwellConfig.healthUri(), String.class);
+      URL url = new URL(this.cromwellConfig.healthUri());
+      URLConnection connection = url.openConnection();
+      connection.setConnectTimeout(5000);
+      var stream = connection.getInputStream();
+
+      result = new String(stream.readAllBytes());
       isOk = true;
     } catch (Exception e) {
       result = e.getLocalizedMessage();

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -4,7 +4,6 @@ import bio.terra.cbas.api.PublicApi;
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.model.SystemStatus;
 import bio.terra.cbas.model.SystemStatusSystems;
-import org.apache.http.client.HttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,5 +40,4 @@ public class PublicApiController implements PublicApi {
             .putSystemsItem("Cromwell", new SystemStatusSystems().ok(isOk).addMessagesItem(result)),
         HttpStatus.OK);
   }
-
 }

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -2,15 +2,38 @@ package bio.terra.cbas.controllers;
 
 import bio.terra.cbas.api.PublicApi;
 import bio.terra.cbas.model.SystemStatus;
+import bio.terra.cbas.model.SystemStatusSystems;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.client.RestTemplate;
 
 @Controller
 public class PublicApiController implements PublicApi {
 
   @Override
   public ResponseEntity<SystemStatus> getStatus() {
-    return new ResponseEntity<>(new SystemStatus().ok(true), HttpStatus.OK);
+
+    RestTemplate restTemplate = new RestTemplate();
+    String x = restTemplate.getForObject("https://www.broadinstitute.org", String.class);
+
+    return new ResponseEntity<>(
+        new SystemStatus()
+            .ok(true)
+            .putSystemsItem(
+                "Cromwell",
+                new SystemStatusSystems().ok(true).addMessagesItem(x.substring(0, 100))),
+        HttpStatus.OK);
   }
+
+  //  private final RestTemplate restTemplate;
+  //
+  //  public RestService(RestTemplateBuilder restTemplateBuilder) {
+  //    this.restTemplate = restTemplateBuilder.build();
+  //  }
+  //
+  //  public String getPostsPlainJSON() {
+  //    String url = "https://jsonplaceholder.typicode.com/posts";
+  //    return this.restTemplate.getForObject(url, String.class);
+  //  }
 }

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -6,6 +6,7 @@ import bio.terra.cbas.model.SystemStatus;
 import bio.terra.cbas.model.SystemStatusSystems;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +33,7 @@ public class PublicApiController implements PublicApi {
       connection.setConnectTimeout(5000);
       var stream = connection.getInputStream();
 
-      result = new String(stream.readAllBytes());
+      result = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
       isOk = true;
     } catch (Exception e) {
       result = e.getLocalizedMessage();

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -42,14 +42,4 @@ public class PublicApiController implements PublicApi {
         HttpStatus.OK);
   }
 
-  //  private final RestTemplate restTemplate;
-  //
-  //  public RestService(RestTemplateBuilder restTemplateBuilder) {
-  //    this.restTemplate = restTemplateBuilder.build();
-  //  }
-  //
-  //  public String getPostsPlainJSON() {
-  //    String url = "https://jsonplaceholder.typicode.com/posts";
-  //    return this.restTemplate.getForObject(url, String.class);
-  //  }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -38,6 +38,11 @@ spring:
   liquibase:
     change-log: changelog/changelog.yaml
 
+workflow-engines:
+  cromwell:
+    baseUri: "http://localhost:8000"
+    healthUri: "http://localhost:8000/engine/v1/status"
+
 terra.common:
   tracing:
     stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}


### PR DESCRIPTION
CBAS `/status` response when Cromwell is running:
```
{
  "ok": true,
  "systems": {
    "Cromwell": {
      "ok": true,
      "messages": [
        "{}"
      ]
    }
  }
}
```
When it's stopped:
```
{
  "ok": true,
  "systems": {
    "Cromwell": {
      "ok": false,
      "messages": [
        "I/O error on GET request for \"http://localhost:8000/engine/v1/status\": Connection refused; nested exception is java.net.ConnectException: Connection refused"
      ]
    }
  }
}
```

As per AC the CBAS global status stays `"ok": true` regardless of what Cromwell is doing.

What explicitly does not work yet (future tickets):
- Running anywhere other than locally, with a local Cromwell
- Using a generated API client instead of a generic HTTP library
  - As demonstrated by Terra Data Catalog calling Rawls [here](https://github.com/DataBiosphere/terra-data-catalog/blob/main/service/src/main/java/bio/terra/catalog/rawls/RawlsService.java#L43).