### PR TITLE
BW-1253: Auto-update helm chart upon CBAS release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,21 @@ jobs:
 
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.GCR_NAME }}
+
+      - name: Update CBAS Helm Chart in cromwhelm
+        env:
+          BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        run: |
+          set -e
+          cd cromwhelm
+          git checkout main
+          ls -la
+          HELM_CUR_TAG=$(grep "/composite-batch-analysis-service:" cromwell-helm/templates/cbas-deployment.yaml | sed "s,.*/composite-batch-analysis-service:,,")
+          HELM_NEW_TAG=${{ steps.tag.outputs.TAG }}
+          [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
+          sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" cromwell-helm/templates/cbas-deployment.yaml
+          git diff
+          git config --global user.name "broadbot"
+          git config --global user.email "broadbot@broadinstitute.org"
+          git commit -am "Auto update to CBAS version $HELM_NEW_TAG"
+          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.GCR_NAME }}
 
+      - name: Clone Cromwhelm
+        uses: actions/checkout@v2
+        with:
+          repository: broadinstitute/cromwhelm
+          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+          path: cromwhelm
+
       - name: Update CBAS Helm Chart in cromwhelm
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Upon publishing a new version to this repo, github will now automatically write the tag associated with that new version into the [broadinstitute/cromwhelm repo](https://github.com/broadinstitute/cromwhelm)'s CBAS Helm Chart.